### PR TITLE
Fix CN partition ECR policy configuration

### DIFF
--- a/backend/byoc/build_and_push.sh
+++ b/backend/byoc/build_and_push.sh
@@ -20,6 +20,8 @@ fi
 
 # Get the account number associated with the current IAM credentials
 account=$(aws sts  get-caller-identity --query Account --output text)
+partition=$(aws sts get-caller-identity --query 'Arn' --output text | cut -d: -f2)
+
 
 VLLM_VERSION=v0.10.1.1
 inference_image=sagemaker_endpoint/vllm
@@ -38,6 +40,9 @@ aws  ecr get-login-password --region $region | docker login --username AWS --pas
 
 # Substitute the AWS account ID into the ECR policy
 sed "s/\${AWS_ACCOUNT_ID}/${account}/g" ecr-policy.json > ecr-policy-temp.json
+sed -i "s/\${AWS_PARTITION}/${partition}/g" ecr-policy-temp.json
+#print file content of ecr-policy-temp
+cat ecr-policy-temp.json
 
 aws ecr set-repository-policy \
     --repository-name "${inference_image}" \

--- a/backend/byoc/ecr-policy.json
+++ b/backend/byoc/ecr-policy.json
@@ -5,7 +5,7 @@
         "Sid": "RestrictedAccountAccess",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:root"
+          "AWS": "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:root"
         },
         "Action": [
           "ecr:CompleteLayerUpload",

--- a/backend/docker/ecr-policy.json
+++ b/backend/docker/ecr-policy.json
@@ -5,7 +5,7 @@
         "Sid": "RestrictedAccountAccess",
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:root"
+          "AWS": "arn:${AWS_PARTITION}::iam::${AWS_ACCOUNT_ID}:root"
         },
         "Action": [
           "ecr:CompleteLayerUpload",

--- a/cn-region-deploy.sh
+++ b/cn-region-deploy.sh
@@ -54,6 +54,9 @@ TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-meta
 EC2_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/public-ipv4)
 # Get the current region and write it to the backend .env file
 REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/placement/region)
+# Get the current partition 
+AWS_PARTITION=$(aws sts get-caller-identity --query 'Arn' --output text | cut -d: -f2)
+
 
 echo "Get IP:$EC2_IP and Region:$REGION " >> "$LOG_FILE"
 # Generate a random string key
@@ -70,6 +73,7 @@ echo "AK=" >> /home/ubuntu/llm_model_hub/backend/.env
 echo "SK=" >> /home/ubuntu/llm_model_hub/backend/.env
 echo "role=${SageMakerRoleArn}" >> /home/ubuntu/llm_model_hub/backend/.env
 echo "region=$REGION" >> /home/ubuntu/llm_model_hub/backend/.env
+echo "partition=$AWS_PARTITION" >> /home/ubuntu/llm_model_hub/backend/.env
 echo "db_host=127.0.0.1" >> /home/ubuntu/llm_model_hub/backend/.env
 echo "db_name=llm" >> /home/ubuntu/llm_model_hub/backend/.env
 echo "db_user=llmdata" >> /home/ubuntu/llm_model_hub/backend/.env


### PR DESCRIPTION
This PR fixes ECR policy configuration for China partition regions.

Changes include:
- Updated ECR policy JSON files for both BYOC and Docker backends
- Added China partition support in build and push scripts
- Enhanced cn-region-deploy.sh with proper ECR configuration

These changes ensure proper ECR access and deployment in China partition (aws-cn) regions.